### PR TITLE
Add mechanical squeezer recipes for end coal, end lapis, end redstone, and end diamond ores. And add mechanical squeezer recipes for certus quartz ores.

### DIFF
--- a/src/scripts/ct/Duplicate.zs
+++ b/src/scripts/ct/Duplicate.zs
@@ -1,5 +1,6 @@
 import crafttweaker.item.IItemStack;
 import mods.integrateddynamics.Squeezer;
+import mods.integrateddynamics.MechanicalSqueezer;
 import mods.advancedrocketry.RollingMachine;
 import mods.advancedrocketry.ArcFurnace;
 import mods.techreborn.plateBendingMachine;
@@ -135,6 +136,10 @@ Squeezer.addRecipe(<netherendingores:ore_end_vanilla:0>, <minecraft:coal:0> * 4,
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:6>, <minecraft:redstone> * 8, 1.0, <minecraft:redstone> * 2, 0.5, <minecraft:redstone> * 2, 0.5);
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:5>, <minecraft:dye:4> * 8, 1.0, <minecraft:dye:4> * 2, 0.5, <minecraft:dye:4> * 2, 0.5);
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:1>, <minecraft:diamond>, 1.0, <minecraft:diamond>, 0.75);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:0>, <minecraft:coal:0> * 6, 1.0, <minecraft:coal:0>, 0.5);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:6>, <minecraft:redstone> * 12, 1.0, <minecraft:redstone> * 2, 0.5);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:5>, <minecraft:dye:4> * 12, 1.0, <minecraft:dye:4> * 2, 0.5);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:1>, <minecraft:diamond> * 2, 1.0, <minecraft:diamond>, 0.50);
 Function.rodding(<ore:ingotAluminum>, <immersiveengineering:material:3>);
 Function.rodding(<ore:ingotIron>, <immersiveengineering:material:1>);
 Function.rodding(<ore:ingotSteel>, <immersiveengineering:material:2>);

--- a/src/scripts/ct/Duplicate.zs
+++ b/src/scripts/ct/Duplicate.zs
@@ -136,10 +136,18 @@ Squeezer.addRecipe(<netherendingores:ore_end_vanilla:0>, <minecraft:coal:0> * 4,
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:6>, <minecraft:redstone> * 8, 1.0, <minecraft:redstone> * 2, 0.5, <minecraft:redstone> * 2, 0.5);
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:5>, <minecraft:dye:4> * 8, 1.0, <minecraft:dye:4> * 2, 0.5, <minecraft:dye:4> * 2, 0.5);
 Squeezer.addRecipe(<netherendingores:ore_end_vanilla:1>, <minecraft:diamond>, 1.0, <minecraft:diamond>, 0.75);
+Squeezer.addRecipe(<appliedenergistics2:quartz_ore>, <appliedenergistics2:material:0> * 2, 1.0, <appliedenergistics2:material:0>, 0.5);
+Squeezer.addRecipe(<appliedenergistics2:charged_quartz_ore>, <appliedenergistics2:material:1> * 2, 1.0, <appliedenergistics2:material:1>, 0.5);
+Squeezer.addRecipe(<netherendingores:ore_nether_modded_1:9>, <appliedenergistics2:material:0> * 2, 1.0, <appliedenergistics2:material:0>, 0.5);
+Squeezer.addRecipe(<netherendingores:ore_nether_modded_1:10>, <appliedenergistics2:material:1> * 2, 1.0, <appliedenergistics2:material:1>, 0.5);
 MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:0>, <minecraft:coal:0> * 6, 1.0, <minecraft:coal:0>, 0.5);
 MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:6>, <minecraft:redstone> * 12, 1.0, <minecraft:redstone> * 2, 0.5);
 MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:5>, <minecraft:dye:4> * 12, 1.0, <minecraft:dye:4> * 2, 0.5);
 MechanicalSqueezer.addRecipe(<netherendingores:ore_end_vanilla:1>, <minecraft:diamond> * 2, 1.0, <minecraft:diamond>, 0.50);
+MechanicalSqueezer.addRecipe(<appliedenergistics2:quartz_ore>, <appliedenergistics2:material:0> * 3, 1.0, <appliedenergistics2:material:0>, 0.5);
+MechanicalSqueezer.addRecipe(<appliedenergistics2:charged_quartz_ore>, <appliedenergistics2:material:1> * 3, 1.0, <appliedenergistics2:material:1>, 0.5);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_nether_modded_1:9>, <appliedenergistics2:material:0> * 3, 1.0, <appliedenergistics2:material:0>, 0.5);
+MechanicalSqueezer.addRecipe(<netherendingores:ore_nether_modded_1:10>, <appliedenergistics2:material:1> * 3, 1.0, <appliedenergistics2:material:1>, 0.5);
 Function.rodding(<ore:ingotAluminum>, <immersiveengineering:material:3>);
 Function.rodding(<ore:ingotIron>, <immersiveengineering:material:1>);
 Function.rodding(<ore:ingotSteel>, <immersiveengineering:material:2>);


### PR DESCRIPTION
## Pull Request Content
<!-- ✍️ Choose one or multiples-->
- [ ] Config
- [ ] Resources(Textures)
- [ ] Resources(Localization)
- [x] Scripts
- [ ] Structures
- [ ] Others
 
## Description
Adds missing mechanical squeezer recipes for end coal ore, end lapis ore, end redstone ore, and end diamond ore.
The recipes are copies of the mechanical squeezer recipes for their vanilla ore variants.