### PR TITLE
Fix iron/gold dupes and allow creating gear casts with stone and enderio gears using brass and aluminium brass

### DIFF
--- a/src/scripts/ct/TConstruct.zs
+++ b/src/scripts/ct/TConstruct.zs
@@ -17,12 +17,37 @@ Melting.removeRecipe(<liquid:gold>, <minecraft:golden_rail>);
 //Dupe bug
 Melting.removeRecipe(<liquid:iron>, <minecraft:minecart>);
 Melting.removeRecipe(<liquid:iron>, <techreborn:iron_furnace>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:hopper>); //craftable using iron alloy
+Melting.removeRecipe(<liquid:gold>, <minecraft:light_weighted_pressure_plate>); //rolling machine dupes
+Melting.removeRecipe(<liquid:iron>, <minecraft:tripwire>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:bucket>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:iron_bars>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:heavy_weighted_pressure_plate>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:iron_door>);
 Melting.removeRecipe(<liquid:copper>, <techreborn:cable>);
 Melting.removeRecipe(<liquid:tin>, <techreborn:cable:1>);
 Melting.removeRecipe(<liquid:gold>, <techreborn:cable:2>);
+
+//Force use of the induction smelter to smelt blends into ingots
 Melting.removeRecipe(<liquid:lumium>, <thermalfoundation:material:102>);
 Melting.removeRecipe(<liquid:signalum>, <thermalfoundation:material:101>);
 Melting.removeRecipe(<liquid:enderium>, <thermalfoundation:material:103>);
+
+//Fix being unable to make gear casts using certain gears and brass or aluminium brass
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <thermalfoundation:material:23>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <thermalfoundation:material:23>, <liquid:alubrass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:10>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:10>, <liquid:alubrass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:11>, <liquid:gold>, 288, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:11>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:11>, <liquid:alubrass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:12>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:12>, <liquid:alubrass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:13>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:13>, <liquid:alubrass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:73>, <liquid:gold>, 288, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:73>, <liquid:brass>, 144, true);
+Casting.addTableRecipe(<tconstruct:cast_custom:4>, <enderio:item_material:73>, <liquid:alubrass>, 144, true);
 
 //Remove direct trait components as they do not respect actual block drops
 for item in scripts.ct.JEI.directs {

--- a/src/scripts/ct/TConstruct.zs
+++ b/src/scripts/ct/TConstruct.zs
@@ -19,7 +19,7 @@ Melting.removeRecipe(<liquid:iron>, <minecraft:minecart>);
 Melting.removeRecipe(<liquid:iron>, <techreborn:iron_furnace>);
 Melting.removeRecipe(<liquid:iron>, <minecraft:hopper>); //craftable using iron alloy
 Melting.removeRecipe(<liquid:gold>, <minecraft:light_weighted_pressure_plate>); //rolling machine dupes
-Melting.removeRecipe(<liquid:iron>, <minecraft:tripwire>);
+Melting.removeRecipe(<liquid:iron>, <minecraft:tripwire_hook>);
 Melting.removeRecipe(<liquid:iron>, <minecraft:bucket>);
 Melting.removeRecipe(<liquid:iron>, <minecraft:iron_bars>);
 Melting.removeRecipe(<liquid:iron>, <minecraft:heavy_weighted_pressure_plate>);
@@ -27,6 +27,7 @@ Melting.removeRecipe(<liquid:iron>, <minecraft:iron_door>);
 Melting.removeRecipe(<liquid:copper>, <techreborn:cable>);
 Melting.removeRecipe(<liquid:tin>, <techreborn:cable:1>);
 Melting.removeRecipe(<liquid:gold>, <techreborn:cable:2>);
+Melting.removeRecipe(<liquid:iron>, <ironchest:iron_chest>);
 
 //Force use of the induction smelter to smelt blends into ingots
 Melting.removeRecipe(<liquid:lumium>, <thermalfoundation:material:102>);

--- a/src/scripts/ct/TConstruct.zs
+++ b/src/scripts/ct/TConstruct.zs
@@ -28,6 +28,7 @@ Melting.removeRecipe(<liquid:copper>, <techreborn:cable>);
 Melting.removeRecipe(<liquid:tin>, <techreborn:cable:1>);
 Melting.removeRecipe(<liquid:gold>, <techreborn:cable:2>);
 Melting.removeRecipe(<liquid:iron>, <ironchest:iron_chest>);
+Melting.removeRecipe(<liquid:iron>, <ironchest:wood_iron_chest_upgrade>);
 
 //Force use of the induction smelter to smelt blends into ingots
 Melting.removeRecipe(<liquid:lumium>, <thermalfoundation:material:102>);

--- a/src/scripts/ct/TE.zs
+++ b/src/scripts/ct/TE.zs
@@ -17,6 +17,20 @@ InductionSmelter.removeRecipe(<thermalfoundation:material:866>, <thermalfoundati
 Pulverizer.removeRecipe(<thermalfoundation:ore:5>);
 Pulverizer.removeRecipe(<thermalfoundation:ore:7>);
 
+//Dupe Bug
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:hopper>); //can be crafted using iron alloy
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:bucket>); //the rest of these are rolling machine dupes
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:minecart>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:chest_minecart>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:furnace_minecart>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:hopper_minecart>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:rail>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:golden_rail>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:light_weighted_pressure_plate>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:heavy_weighted_pressure_plate>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:iron_door>);
+InductionSmelter.removeRecipe(<minecraft:sand>, <minecraft:iron_bars>);
+Pulverizer.removeRecipe(<techreborn:dynamiccell>);
 
 //add
 var coils = [<thermalfoundation:material:513>, <thermalfoundation:material:514>, <thermalfoundation:material:515>] as IItemStack[];


### PR DESCRIPTION
## Pull Request Content
<!-- ✍️ Choose one or multiples-->
- [ ] Config
- [ ] Resources(Textures)
- [ ] Resources(Localization)
- [x] Scripts
- [ ] Structures
- [ ] Others
 
## Description
<!-- ✍️ A clear and precise description of the content-->
-Removes some melting and induction smelting recipes that can be used to dupe iron or gold (most of them are caused by the Rolling Machine)
-Adds recipes for gear casts using stone gears and enderio gears for all cast liquid types (gold, brass, aluminum brass).
Note: it isn't possible to remove specific recipes for gear casts, I would have removed the enderio gear cast recipes instead if it were possible.

## Additional Work
<!-- ✍️ Any additional work that needs to be done by the modpack team-->
No additional work should be needed